### PR TITLE
Add Top.gg Discord bot widget to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 [![Profile Views](https://komarev.com/ghpvc/?username=ItsChakal&style=for-the-badge&color=98b982)](https://github.com/ItsChakal)
 [![WakaTime](https://wakatime.com/badge/user/5f5b6129-4bae-4b24-a1ae-61a35b02a21d.svg?style=for-the-badge)](https://wakatime.com/@ItsChakal)
+[![Discord Bots](https://top.gg/api/widget/1215070970013032478.svg)](https://top.gg/bot/1215070970013032478)
 
 </div>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add Top.gg Discord bot widget badge to `README.md`
- fix link syntax so the badge is clickable and points to the bot page

## Testing
- not applicable (README-only change)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc8f02d3-a4b6-421b-8bc5-1ceaafccdaf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc8f02d3-a4b6-421b-8bc5-1ceaafccdaf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

